### PR TITLE
pcapplusplus: pass CPPFLAGS+CXXFLAGS to 3rd party sources

### DIFF
--- a/recipes/pcapplusplus/all/conandata.yml
+++ b/recipes/pcapplusplus/all/conandata.yml
@@ -2,3 +2,7 @@ sources:
   "21.05":
     url: "https://github.com/seladb/PcapPlusPlus/archive/v21.05.tar.gz"
     sha256: "f7bc2caea72544f42e3547c8acf65fca07ddd4cd45f7be2f5132dd1826ea27bb"
+patches:
+  "21.05":
+    - patch_file: "patches/0001-Pass-CXXFLAGS-CPPFLAGS-when-compiling-3rd-party-sour.patch"
+      base_path: "source_subfolder"

--- a/recipes/pcapplusplus/all/conanfile.py
+++ b/recipes/pcapplusplus/all/conanfile.py
@@ -2,6 +2,8 @@ from conans import ConanFile, tools, AutoToolsBuildEnvironment
 from conans.errors import ConanInvalidConfiguration
 import os
 
+required_conan_version = ">=1.33.0"
+
 
 class PcapplusplusConan(ConanFile):
     name = "pcapplusplus"
@@ -13,20 +15,24 @@ class PcapplusplusConan(ConanFile):
     homepage = "https://github.com/seladb/PcapPlusPlus"
     settings = "os", "compiler", "build_type", "arch"
     options = {
+        "fPIC": [True, False],
         "immediate_mode": [True, False],
     }
     default_options = {
+        "fPIC": True,
         "immediate_mode": False,
     }
+
+    exports_sources = "patches/*"
     generators = "make"
 
-    _source_subfolder = "PcapPlusPlus"
+    @property
+    def _source_subfolder(self):
+        return "source_subfolder"
 
-    def configure(self):
-        if self.settings.os not in ["Macos", "Linux"]:
-            raise ConanInvalidConfiguration("%s is not supported" % self.settings.os)
-
-        del self.settings.compiler.libcxx
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
 
     def requirements(self):
         if self.settings.os == "Windows":
@@ -35,37 +41,56 @@ class PcapplusplusConan(ConanFile):
         else:
             self.requires("libpcap/1.9.1")
 
+    def validate(self):
+        if self.settings.os not in ("FreeBSD", "Linux", "Macos"):
+            raise ConanInvalidConfiguration("%s is not supported" % self.settings.os)
+
     def source(self):
-        tools.get(
-            **self.conan_data["sources"][self.version],
-            destination=self._source_subfolder, 
-            strip_root=True,
-        )
+        tools.get(**self.conan_data["sources"][self.version],
+            destination=self._source_subfolder, strip_root=True)
+
+    @property
+    def _configure_sh_script(self):
+        return {
+            "Android": "configure-android.sh",
+            "Linux": "configure-linux.sh",
+            "Macos": "configure-mac_os_x.sh",
+            "FreeBSD": "configure-freebsd.sh",
+        }[str(self.settings.os)]
+
+    def _patch_sources(self):
+        if not self.options.get_safe("fPIC"):
+            tools.replace_in_file(os.path.join(self._source_subfolder, "PcapPlusPlus.mk.common"),
+                                  "-fPIC", "")
+        for patch in self.conan_data.get("patches", {}).get(self.version, []):
+            tools.patch(**patch)
 
     def build(self):
+        self._patch_sources()
         with tools.chdir(self._source_subfolder):
-            config_script = "configure-linux.sh" if self.settings.os == "Linux" else "configure-mac_os_x.sh"
-            libpcap_include_path = self.deps_cpp_info["libpcap"].include_paths[0]
-            libpcap_lib_path = self.deps_cpp_info["libpcap"].lib_paths[0]
-            config_command = ("./%s --libpcap-include-dir %s --libpcap-lib-dir %s" % (config_script, libpcap_include_path, libpcap_lib_path))
+            config_args = [
+                "./{}".format(self._configure_sh_script),
+                "--libpcap-include-dir", tools.unix_path(self.deps_cpp_info["libpcap"].include_paths[0]),
+                "--libpcap-lib-dir", tools.unix_path(self.deps_cpp_info["libpcap"].lib_paths[0]),
+            ]
             if self.options.immediate_mode:
-                config_command += " --use-immediate-mode"
+                config_args.append("--use-immediate-mode")
+            if tools.is_apple_os(self.settings.os) and "arm" in self.settings.arch:
+                config_args.append("--arm64")
 
-            self.run(config_command)
-
-            env_build = AutoToolsBuildEnvironment(self)
-            env_build.make(target="libs")
+            autotools = AutoToolsBuildEnvironment(self)
+            with tools.environment_append(autotools.vars):
+                self.run(" ".join(config_args), run_environment=True)
+                autotools.make(target="libs")
 
     def package(self):
         self.copy(pattern="LICENSE", dst="licenses", src=self._source_subfolder, keep_path=False)
-        self.copy("*.h", dst="include", src="PcapPlusPlus/Dist/header")
-        self.copy("*.a", dst="lib", src="PcapPlusPlus/Dist/", keep_path=False)
+        self.copy("*.h", dst="include", src=os.path.join(self._source_subfolder, "Dist", "header"))
+        self.copy("*.a", dst="lib", src=os.path.join(self._source_subfolder, "Dist"), keep_path=False)
 
     def package_info(self):
         self.cpp_info.libs = ["Pcap++", "Packet++", "Common++"]
         if self.settings.os == "Linux":
             self.cpp_info.system_libs.append("pthread")
         if self.settings.os == "Macos":
-            self.cpp_info.frameworks.append("CoreFoundation")
-            self.cpp_info.frameworks.append("Security")
-            self.cpp_info.frameworks.append("SystemConfiguration")
+            self.cpp_info.frameworks.extend(["CoreFoundation", "Security", "SystemConfiguration"])

--- a/recipes/pcapplusplus/all/patches/0001-Pass-CXXFLAGS-CPPFLAGS-when-compiling-3rd-party-sour.patch
+++ b/recipes/pcapplusplus/all/patches/0001-Pass-CXXFLAGS-CPPFLAGS-when-compiling-3rd-party-sour.patch
@@ -1,0 +1,22 @@
+--- 3rdParty/LightPcapNg/Makefile
++++ 3rdParty/LightPcapNg/Makefile
+@@ -15,7 +15,7 @@
+ 
+ Obj/%.o: LightPcapNg/src/%.c
+ 	@echo Building file: $<
+-	@$(CC) $(INCLUDES) -Wall -O2 $(GLOBAL_FLAGS) $(DEFS) -g -c -o "$@" "$<"
++	@$(CC) $(CPPFLAGS) $(CXXFLAGS) $(INCLUDES) -Wall -O2 $(GLOBAL_FLAGS) $(DEFS) -g -c -o "$@" "$<"
+ 
+ CUR_TARGET := $(notdir $(shell pwd))
+ 
+--- 3rdParty/hash-library/Makefile
++++ 3rdParty/hash-library/Makefile
+@@ -13,7 +13,7 @@ DEFS := -DUNIVERSAL -fPIC
+ 
+ Obj/%.o: %.cpp
+ 	@echo Building file: $<
+-	@$(CXX) $(INCLUDES) -Wall -O2 $(GLOBAL_FLAGS) $(DEFS) -g -c -o "$@" "$<"
++	@$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(INCLUDES) -Wall -O2 $(GLOBAL_FLAGS) $(DEFS) -g -c -o "$@" "$<"
+ 
+ CUR_TARGET := $(notdir $(shell pwd))
+ 

--- a/recipes/pcapplusplus/all/test_package/conanfile.py
+++ b/recipes/pcapplusplus/all/test_package/conanfile.py
@@ -8,7 +8,6 @@ class PcapplusplusTestConan(ConanFile):
 
     def build(self):
         cmake = CMake(self)
-        cmake.verbose = True
         cmake.configure()
         cmake.build()
 

--- a/recipes/pcapplusplus/all/test_package/conanfile.py
+++ b/recipes/pcapplusplus/all/test_package/conanfile.py
@@ -1,21 +1,19 @@
-from conans import ConanFile, CMake
+from conans import ConanFile, CMake, tools
 import os
-import logging
 
 
 class PcapplusplusTestConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
     generators = "cmake"
- 
-    def configure(self):
-        del self.settings.compiler.libcxx
 
     def build(self):
         cmake = CMake(self)
+        cmake.verbose = True
         cmake.configure()
         cmake.build()
 
     def test(self):
-        bin_path = os.path.join("bin", "test_package")
-        pcap_file_path = os.path.join(self.source_folder, "1_packet.pcap")
-        self.run("{0} {1}".format(bin_path, pcap_file_path), run_environment=True)
+        if not tools.cross_building(self):
+            bin_path = os.path.join("bin", "test_package")
+            pcap_file_path = os.path.join(self.source_folder, "1_packet.pcap")
+            self.run("{0} {1}".format(bin_path, pcap_file_path), run_environment=True)


### PR DESCRIPTION
The 3rd party sources also need `CPPFLAGS` + `CXXFLAGS` passed.

When using clang + libc++, `CXXFLAGS` contains `-stdlib=libc++`.